### PR TITLE
Update /var/log/btmp default permissions

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -8,6 +8,7 @@ transport:
 
 provisioner:
   name: dokken
+  chef_license: accept
 
 verifier:
   name: inspec

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  chef_license: accept
   # We have tests that ensure our deprecated features still
   # work so we can't turn this on globally.
   # deprecations_as_errors: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,6 @@ matrix:
   include:
     - script:
       - make travis
-      env: UNIT_AND_LINT=1
+      env:
+        - UNIT_AND_LINT=1
+        - CHEF_LICENSE=accept

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,7 +50,7 @@ default['logrotate']['global'] = {
   '/var/log/btmp' => {
     'missingok' => true,
     'monthly' => true,
-    'create' => '0660 root utmp',
+    'create' => '0600 root utmp',
     'rotate' => 1,
   },
 }


### PR DESCRIPTION
Both RHEL 7 and RHEL 8 defaults are `0600`. Unsure if this deviation is technically a bug or was done intentionally.