### PR TITLE
[ISSUE-138] - EL8 files conflict with default attrs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,22 +35,30 @@ default['logrotate']['cron']['command'] = '/usr/sbin/logrotate /etc/logrotate.co
 default['logrotate']['cron']['minute'] = 35
 default['logrotate']['cron']['hour'] = 2
 
-default['logrotate']['global'] = {
-  'weekly' => true,
-  'rotate' => 4,
-  'create' => '',
+if platform_family?('rhel') && node['platform_version'].to_i >= 8
+    default['logrotate']['global'] = {
+      'weekly' => true,
+      'rotate' => 4,
+      'create' => '',
+    }
+else
+  default['logrotate']['global'] = {
+    'weekly' => true,
+    'rotate' => 4,
+    'create' => '',
 
-  '/var/log/wtmp' => {
-    'missingok' => true,
-    'monthly' => true,
-    'create' => '0664 root utmp',
-    'rotate' => 1,
-  },
+    '/var/log/wtmp' => {
+      'missingok' => true,
+      'monthly' => true,
+      'create' => '0664 root utmp',
+      'rotate' => 1,
+    },
 
-  '/var/log/btmp' => {
-    'missingok' => true,
-    'monthly' => true,
-    'create' => '0600 root utmp',
-    'rotate' => 1,
-  },
-}
+    '/var/log/btmp' => {
+      'missingok' => true,
+      'monthly' => true,
+      'create' => '0600 root utmp',
+      'rotate' => 1,
+    },
+  }
+end


### PR DESCRIPTION
Addresses an issue where EL8 comes with logrotation
logic for `/var/log/btmp` and `/var/log/wtmp` already but the
logrotate cookbook wants to provide its own logic. This
results in logrotate execution errors.

Signed-off-by: Jeff Blaine <jblaine@kickflop.net>

<!--- Provide a short summary of your changes in the Title above -->

### Description
Addresses an issue where EL8 comes with logrotation
logic for `/var/log/btmp` and `/var/log/wtmp` already but the
logrotate cookbook wants to provide its own logic. This
results in logrotate execution errors.

### Issues Resolved
#138 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>